### PR TITLE
drivers: clk: remove stm32_clock_*() helper

### DIFF
--- a/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_syscfg.c
+++ b/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_syscfg.c
@@ -47,8 +47,9 @@ void stm32mp_syscfg_enable_io_compensation(void)
 	vaddr_t syscfg_base = get_syscfg_base();
 	uint64_t timeout_ref = 0;
 
-	stm32_clock_enable(CK_CSI);
-	stm32_clock_enable(SYSCFG);
+	if (clk_enable(stm32mp_rcc_clock_id_to_clk(CK_CSI)) ||
+	    clk_enable(stm32mp_rcc_clock_id_to_clk(SYSCFG)))
+		panic();
 
 	io_setbits32(syscfg_base + SYSCFG_CMPENSETR, SYSCFG_CMPENSETR_MPU_EN);
 
@@ -86,8 +87,8 @@ void stm32mp_syscfg_disable_io_compensation(void)
 
 	io_clrbits32(syscfg_base + SYSCFG_CMPENSETR, SYSCFG_CMPENSETR_MPU_EN);
 
-	stm32_clock_disable(SYSCFG);
-	stm32_clock_disable(CK_CSI);
+	clk_disable(stm32mp_rcc_clock_id_to_clk(CK_CSI));
+	clk_disable(stm32mp_rcc_clock_id_to_clk(SYSCFG));
 }
 
 static TEE_Result stm32mp1_iocomp(void)

--- a/core/arch/arm/plat-stm32mp1/pm/psci.c
+++ b/core/arch/arm/plat-stm32mp1/pm/psci.c
@@ -113,7 +113,7 @@ void stm32mp_register_online_cpu(void)
 			stm32_pm_cpu_power_down_wfi();
 			panic();
 		}
-		stm32_clock_disable(RTCAPB);
+		clk_disable(stm32mp_rcc_clock_id_to_clk(RTCAPB));
 	}
 
 	core_state[pos] = CORE_ON;
@@ -207,7 +207,8 @@ int psci_cpu_off(void)
 	unlock_state_access(exceptions);
 
 	/* Enable BKPREG access for the disabled CPU */
-	stm32_clock_enable(RTCAPB);
+	if (clk_enable(stm32mp_rcc_clock_id_to_clk(RTCAPB)))
+		panic();
 
 	thread_mask_exceptions(THREAD_EXCP_ALL);
 	stm32_pm_cpu_power_down_wfi();

--- a/core/arch/arm/plat-stm32mp1/stm32_util.h
+++ b/core/arch/arm/plat-stm32mp1/stm32_util.h
@@ -66,15 +66,6 @@ static inline void stm32mp_register_online_cpu(void)
 uint32_t may_spin_lock(unsigned int *lock);
 void may_spin_unlock(unsigned int *lock, uint32_t exceptions);
 
-/*
- * Util for clock gating and to get clock rate for stm32 and platform drivers
- * @id: Target clock ID, ID used in clock DT bindings
- */
-void stm32_clock_enable(unsigned long id);
-void stm32_clock_disable(unsigned long id);
-unsigned long stm32_clock_get_rate(unsigned long id);
-bool stm32_clock_is_enabled(unsigned long id);
-
 /* Helper from platform RCC clock driver */
 struct clk *stm32mp_rcc_clock_id_to_clk(unsigned long clock_id);
 

--- a/core/drivers/clk/clk-stm32mp15.c
+++ b/core/drivers/clk/clk-stm32mp15.c
@@ -1219,12 +1219,12 @@ static void enable_static_secure_clocks(void)
 	};
 
 	for (idx = 0; idx < ARRAY_SIZE(secure_enable); idx++) {
-		stm32_clock_enable(secure_enable[idx]);
+		clk_enable(stm32mp_rcc_clock_id_to_clk(secure_enable[idx]));
 		stm32mp_register_clock_parents_secure(secure_enable[idx]);
 	}
 
 	if (CFG_TEE_CORE_NB_CORE > 1)
-		stm32_clock_enable(RTCAPB);
+		clk_enable(stm32mp_rcc_clock_id_to_clk(RTCAPB));
 }
 
 static void __maybe_unused enable_rcc_tzen(void)
@@ -1485,41 +1485,6 @@ static TEE_Result register_stm32mp1_clocks(void)
 	}
 
 	return TEE_SUCCESS;
-}
-
-/* Route platform legacy clock functions to clk driver functions */
-bool stm32_clock_is_enabled(unsigned long clock_id)
-{
-	struct clk *clk = clock_id_to_clk(clock_id);
-
-	assert(clk);
-	return clk_is_enabled(clk);
-}
-
-void stm32_clock_enable(unsigned long clock_id)
-{
-	struct clk *clk = clock_id_to_clk(clock_id);
-	TEE_Result __maybe_unused res = TEE_ERROR_GENERIC;
-
-	assert(clk);
-	res = clk_enable(clk);
-	assert(!res);
-}
-
-void stm32_clock_disable(unsigned long clock_id)
-{
-	struct clk *clk = clock_id_to_clk(clock_id);
-
-	assert(clk);
-	clk_disable(clk);
-}
-
-unsigned long stm32_clock_get_rate(unsigned long clock_id)
-{
-	struct clk *clk = clock_id_to_clk(clock_id);
-
-	assert(clk);
-	return clk_get_rate(clk);
 }
 
 #ifdef CFG_DRIVERS_CLK_DT


### PR DESCRIPTION
Clean an old API that is deprecated.